### PR TITLE
Update RPRViewer builds 

### DIFF
--- a/render_service_scripts/configure_viewer.py
+++ b/render_service_scripts/configure_viewer.py
@@ -89,7 +89,7 @@ def main():
 		json.dump(config, f, indent=' ', sort_keys=True)
 		
 	# parse scene name
-	filename = args.scene_name
+	filename = args.scene_name.rsplit('.', 1)[0]
 
 	# pack zip
 	repeat_launch = False

--- a/render_service_scripts/configure_viewer.py
+++ b/render_service_scripts/configure_viewer.py
@@ -9,7 +9,7 @@ from render_service_scripts.unpack import unpack_all
 import shutil
 
 # logging
-logging.basicConfig(filename="python_log.txt", level=logging.INFO)
+logging.basicConfig(filename="launch_render_log.txt", level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 

--- a/render_service_scripts/configure_viewer.py
+++ b/render_service_scripts/configure_viewer.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 def build_viewer_pack(version, filename):
 		try:
 			zip_name = "RPRViewerPack_{}_{}".format(version, filename)	
-			shutil.make_archive(zip_name, 'zip', 'scene')
+			shutil.make_archive(zip_name, 'zip', 'viewer_dir')
 		except Exception as ex:
 			logger.error("Zip package build failed.")
 			logger.error(str(ex))
@@ -39,7 +39,7 @@ def main():
 	gltf_file = ""
 	ui_config = ""
 	
-	for rootdir, dirs, files in os.walk("scene"):
+	for rootdir, dirs, files in os.walk(os.path.join('viewer_dir', 'scene')):
 		for file in files:
 			if file.endswith('.gltf'):
 				gltf_file = os.path.join("scene", file)
@@ -59,10 +59,10 @@ def main():
 		logger.error("No UI config in the package!")
 
 	# read config json file
-	if os.path.isfile("config.json"):
+	if os.path.isfile(os.path.join('viewer_dir', 'config.json')):
 		logger.info("Found config file.")
 		try:
-			with open("config.json") as f:
+			with open(os.path.join('viewer_dir', 'config.json')) as f:
 				config = json.loads(f.read())
 			logger.info("Config file was read successfuly.")
 		except Exception as ex:
@@ -85,7 +85,7 @@ def main():
 		
 	config['uiConfig'] = ui_config
 
-	with open('config.json', 'w') as f:
+	with open(os.path.join('viewer_dir', 'config.json'), 'w') as f:
 		json.dump(config, f, indent=' ', sort_keys=True)
 		
 	# parse scene name
@@ -103,14 +103,14 @@ def main():
 	config['save_frames'] = "yes"
 	config['iterations_per_frame'] = int(args.iterations)
 	config['frame_exit_after'] = 1
-	with open('config.json', 'w') as f:
+	with open(os.path.join('viewer_dir', 'config.json'), 'w') as f:
 		json.dump(config, f, indent=' ')
 	
 	# Fix empty stdout 113 line.
 	stdout, stderr = (b'', b'')
 
-	if os.path.isfile("RadeonProViewer.exe"):
-		p = psutil.Popen("RadeonProViewer.exe", stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+	if os.path.isfile(os.path.join('viewer_dir', 'RadeonProViewer.exe')):
+		p = psutil.Popen(os.path.join('viewer_dir', 'RadeonProViewer.exe'), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 		try:
 			stdout, stderr = p.communicate(timeout=300)
 		except (subprocess.TimeoutExpired, psutil.TimeoutExpired) as err:
@@ -144,7 +144,7 @@ def main():
 if __name__ == "__main__":
 	try_count = 0
 	# unpack all archives
-	unpack_all(os.getcwd(), delete=True)
+	unpack_all(os.path.join('.', 'viewer_dir'), delete=True, output_dir=os.path.join('.', 'viewer_dir'))
 	while try_count < 3:
 		try:
 			main()

--- a/render_service_scripts/configure_viewer.py
+++ b/render_service_scripts/configure_viewer.py
@@ -109,8 +109,11 @@ def main():
 	# Fix empty stdout 113 line.
 	stdout, stderr = (b'', b'')
 
-	if os.path.isfile(os.path.join('viewer_dir', 'RadeonProViewer.exe')):
-		p = psutil.Popen(os.path.join('viewer_dir', 'RadeonProViewer.exe'), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+	#change dir before call viewer (it search config in current dir)
+	os.chdir('viewer_dir')
+
+	if os.path.isfile('RadeonProViewer.exe'):
+		p = psutil.Popen('RadeonProViewer.exe', stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 		try:
 			stdout, stderr = p.communicate(timeout=300)
 		except (subprocess.TimeoutExpired, psutil.TimeoutExpired) as err:
@@ -140,6 +143,9 @@ def main():
 	else:
 		logger.error("Failed! No exe file in package.")
 		exit(1)
+
+	#return to workdir
+	os.chdir('..')
 	
 if __name__ == "__main__":
 	try_count = 0

--- a/render_service_scripts/configure_viewer.py
+++ b/render_service_scripts/configure_viewer.py
@@ -5,6 +5,7 @@ import subprocess
 import psutil
 import logging
 import traceback
+from render_service_scripts.unpack import unpack_all
 
 # logging
 logging.basicConfig(filename="python_log.txt", level=logging.INFO)
@@ -15,13 +16,15 @@ def main():
 
 	parser = argparse.ArgumentParser()
 	parser.add_argument('--scene_name')
-	parser.add_argument('--scene_version')
 	parser.add_argument('--version')
 	parser.add_argument('--width')
 	parser.add_argument('--height')
 	parser.add_argument('--engine')
 	parser.add_argument('--iterations')
 	args = parser.parse_args()
+
+	# unpack all archives
+	unpack_all(os.path.abspath(os.getcwd()), delete=True)
 
 	# find GLTF scene and UIConfig
 	gltf_file = ""

--- a/render_service_scripts/configure_viewer.py
+++ b/render_service_scripts/configure_viewer.py
@@ -136,6 +136,8 @@ def main():
 		
 		if not os.path.isfile("img0001.png") and args.engine != "ogl":
 			logger.error("Failed to render image! Retry ...")
+			#return to workdir
+			os.chdir('..')
 			raise Exception("No image")
 		else:
 			logger.info("Testing was finished successfuly.")

--- a/render_service_scripts/configure_viewer.py
+++ b/render_service_scripts/configure_viewer.py
@@ -100,7 +100,7 @@ def main():
 	if not repeat_launch:
 		build_viewer_pack(args.version, filename)
 
-	config['save_frames'] = "yes"
+	config['save_frames'] = True
 	config['iterations_per_frame'] = int(args.iterations)
 	config['frame_exit_after'] = 1
 	with open(os.path.join('viewer_dir', 'config.json'), 'w') as f:

--- a/render_service_scripts/configure_viewer.py
+++ b/render_service_scripts/configure_viewer.py
@@ -24,7 +24,7 @@ def main():
 	args = parser.parse_args()
 
 	# unpack all archives
-	unpack_all(os.path.abspath(os.getcwd()), delete=True)
+	unpack_all(os.getcwd(), delete=True)
 
 	# find GLTF scene and UIConfig
 	gltf_file = ""

--- a/render_service_scripts/download_viewer.py
+++ b/render_service_scripts/download_viewer.py
@@ -1,6 +1,5 @@
 import requests
 import argparse
-import config
 import urllib3
 import logging
 import os
@@ -14,6 +13,8 @@ def main():
 
 	parser = argparse.ArgumentParser()
 	parser.add_argument('--version')
+	parser.add_argument('--jenkins_username')
+	parser.add_argument('--jenkins_password')
 	args = parser.parse_args()
 
 	urllib3.disable_warnings()
@@ -22,7 +23,7 @@ def main():
 	while try_count < 3:
 		try:
 			response = requests.get("https://rpr.cis.luxoft.com/job/RadeonProViewerAuto/job/master/{}/artifact/RprViewer_Windows.zip"\
-				.format(args.version), auth=(config.jenkins_username, config.jenkins_password), verify=False, timeout=None)
+				.format(args.version), auth=(args.jenkins_username, args.jenkins_password), verify=False, timeout=None)
 			original_size = response.headers['Content-Length']
 			logger.info("Original size: " + original_size)
 		

--- a/render_service_scripts/send_viewer_results.py
+++ b/render_service_scripts/send_viewer_results.py
@@ -1,7 +1,12 @@
 import requests
-import config
 import json
 import argparse
+import os
+import logging
+
+# logging
+logging.basicConfig(filename="python_log.txt", level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 
 def main():
@@ -10,59 +15,41 @@ def main():
 	parser.add_argument('--status')
 	parser.add_argument('--id')
 	parser.add_argument('--django_ip')
-	parser.add_argument('--jenkins_job')
 	parser.add_argument('--build_number')
 	args = parser.parse_args()
 
-	django_url = args.django_ip
+	# preparing dict with output files for post
+	files = {}
+	# search zip archive and logs
+	output_files = os.listdir('.')
+	for output_file in output_files:
+		if output_file.endswith('.zip') or output_file.endswith('.txt'):
+			files.update({output_file: open(output_file, 'rb')})
+	# search output image and logs
+	output_files = os.listdir('viewer_dir')
+	for output_file in output_files:
+		if output_file.endswith('.txt') or output_file == 'img0001.png':
+			files.update({output_file: open(os.path.join('viewer_dir', output_file), 'rb')})
+	logger.info("Output files: {}".format(files))
+
+	post_data = {'status': args.status, 'id': args.id, 'build_number': args.build_number}
 
 	try_count = 0
 	while try_count < 3:
 		try:
-			response = requests.get("http://rpr.cis.luxoft.com/job/{jenkins_job}/{build_number}/api/json?pretty=true".format(jenkins_job=args.jenkins_job, build_number=args.build_number), \
-				auth=(config.jenkins_username, config.jenkins_password))
+			response = requests.post(args.django_ip, data=post_data, files=files)
 			if response.status_code  == 200:
-				print("GET request successfuly done.")
+				logger.info("POST request successfuly sent.")
 				break
 			else:
-				print("GET request failed, status code: " + str(response.status_code))
+				logger.info("POST reques failed, status code: " + str(response.status_code))
 				break
 		except Exception as e:
 			if try_count == 2:
-				print("GET request try 3 failed. Finishing work.")
+				logger.info("POST request try 3 failed. Finishing work.")
 				break
 			try_count += 1
-			print("GET request failed. Retry ...")
-		
-
-	job_json = json.loads(response.text)
-
-	artifacts = {}
-	for job in job_json['artifacts']:
-		artifacts[job['fileName']] = "http://172.30.23.112:8088/job/{jenkins_job}/{build_number}/artifact/{art}"\
-			.format(jenkins_job=args.jenkins_job, build_number=args.build_number, art=job['relativePath'])
-
-	zip_link = "http://172.30.23.112:8088/job/{jenkins_job}/{build_number}/artifact/*zip*/archive.zip"\
-																					.format(jenkins_job=args.jenkins_job, build_number=args.build_number)
-
-	post_data = {'status': args.status, 'artifacts':str(artifacts), 'id': args.id, 'zip_link':zip_link, 'build_number': args.build_number}
-
-	try_count = 0
-	while try_count < 3:	
-		try:
-			response = requests.post(django_url, data=post_data)
-			if response.status_code  == 200:
-				print("POST request successfuly sent.")
-				break
-			else:
-				print("POST request failed, status code: " + str(response.status_code))
-				break
-		except Exception as e:
-			if try_count == 2:
-				print("POST request try 3 failed. Finishing work.")
-				break
-			try_count += 1
-			print("POST request failed. Retry ...")
+			logger.info("POST request failed. Retry ...")
 		
 if __name__ == "__main__":
 	main()

--- a/render_service_scripts/send_viewer_results.py
+++ b/render_service_scripts/send_viewer_results.py
@@ -5,7 +5,7 @@ import os
 import logging
 
 # logging
-logging.basicConfig(filename="python_log.txt", level=logging.INFO)
+logging.basicConfig(filename="launch_render_log.txt", level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 

--- a/render_service_scripts/unpack.py
+++ b/render_service_scripts/unpack.py
@@ -26,7 +26,7 @@ def unpack_scene(scene_name, delete=False):
 def unpack_all(dir, delete=False):
     for entry in os.scandir(dir):
         if entry.name.endswith('.zip') or entry.name.endswith('.7z'):
-            unpack_scene(entry, delete)
+            unpack_scene(entry.path, delete)
 
 
 if __name__ == '__main__':

--- a/render_service_scripts/unpack.py
+++ b/render_service_scripts/unpack.py
@@ -10,11 +10,11 @@ logging.basicConfig(filename="launch_render_log.txt", level=logging.INFO,
 shutil.register_unpack_format('7zip', ['.7z'], unpack_7zarchive)
 
 
-def unpack_scene(scene_name, delete=False):
+def unpack_scene(scene_name, delete=False, output_dir='.'):
     if scene_name.endswith('.zip') or scene_name.endswith('.7z'):
         try:
             logging.info('Unpack {}'.format(scene_name))
-            shutil.unpack_archive(scene_name, '.')
+            shutil.unpack_archive(scene_name, output_dir)
             if delete:
                 logging.info('Delete archive {}'.format(scene_name))
                 os.remove(scene_name)
@@ -23,10 +23,10 @@ def unpack_scene(scene_name, delete=False):
             logging.error('No such archive')
 
 
-def unpack_all(dir, delete=False):
+def unpack_all(dir, delete=False, output_dir='.'):
     for entry in os.scandir(dir):
         if entry.name.endswith('.zip') or entry.name.endswith('.7z'):
-            unpack_scene(entry.path, delete)
+            unpack_scene(entry.path, delete, output_dir)
 
 
 if __name__ == '__main__':

--- a/render_service_scripts/unpack.py
+++ b/render_service_scripts/unpack.py
@@ -10,20 +10,23 @@ logging.basicConfig(filename="launch_render_log.txt", level=logging.INFO,
 shutil.register_unpack_format('7zip', ['.7z'], unpack_7zarchive)
 
 
-def unpack_scene(scene_name):
+def unpack_scene(scene_name, delete=False):
     if scene_name.endswith('.zip') or scene_name.endswith('.7z'):
         try:
             logging.info('Unpack {}'.format(scene_name))
             shutil.unpack_archive(scene_name, '.')
+            if delete:
+                logging.info('Delete archive {}'.format(scene_name))
+                os.remove(scene_name)
         except Exception as e:
             logging.error(str(e))
             logging.error('No such archive')
 
 
-def unpack_all(dir):
+def unpack_all(dir, delete=False):
     for entry in os.scandir(dir):
         if entry.name.endswith('.zip') or entry.name.endswith('.7z'):
-            unpack_scene(entry)
+            unpack_scene(entry, delete)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
* JIRA TICKET:

  * https://adc.luxoft.com/jira/browse/STVCIS-801

* PURPOSE

  * Stabilize RPRViewer builds and update its page in redner service

* EFFECT OF CHANGE

  * Apply last changes for RPRViewer page in render service (archives unpack in python script, downloading scene with auth, downloading scripts repository, removing scene versioning).
  * Fix initialization of options in config.
  * Change result artifacts saving realization.
  * Add attempts support for viewer.

* TECHNICAL STEPS

  * See connecting PRs in other repositories:
    * https://gitlab.cts.luxoft.com/services/render_service/-/merge_requests/29
    * https://github.com/luxteam/rpr_pipelines/pull/78
  * Specify demo job in render service config: https://rpr.cis.luxoft.com/job/DemoRenderServiceViewerJob/
  * Open viewer page, upload archive with RPRViewer scene and start render.

* NOTES FOR REVIEWERS

  * In last build of RPRViewer (270) works only hybrid render engine and only if rendering machine window is open via rdp.