### PR TITLE
[Render Service] Create scene scanning API (Blender)

### DIFF
--- a/install/requirements.txt
+++ b/install/requirements.txt
@@ -3,3 +3,4 @@ psutil==5.7.0
 pyscreenshot==1.0
 py7zr==0.5.3
 file_read_backwards==2.0.0
+jinja2==2.11.2

--- a/render_service_scripts/scene_scanning/launch_blender.py
+++ b/render_service_scripts/scene_scanning/launch_blender.py
@@ -107,9 +107,7 @@ def main():
 	if args.action == 'read':
 		blender_script = blender_script_template.render(res_path=os.getcwd(), scene_path=blender_scene, options_structure=options_structure)
 	elif args.action == 'write':
-		blender_script = blender_script_template.format(res_path=os.getcwd(), scene_path=blender_scene, 
-			border_max_x=options['border_max_x'], border_max_y=options['border_max_y'], border_min_x=options['border_min_x'], border_min_y=options['border_min_y'],
-			fps=options['fps'], fps_base=options['fps_base'], tile_x=options['tile_x'], tile_y=options['tile_y'], camera=options['active_camera'])
+		blender_script = blender_script_template.render(res_path=os.getcwd(), scene_path=blender_scene, options_structure=options_structure, configuration_options=configuration_options)
 	else:
 		logger.error("Unknown action: {}".format(args.action))
 

--- a/render_service_scripts/scene_scanning/launch_blender.py
+++ b/render_service_scripts/scene_scanning/launch_blender.py
@@ -10,6 +10,7 @@ import psutil
 from render_service_scripts.unpack import unpack_scene
 from render_service_scripts.pack import update_scene_in_archive
 from requests.auth import HTTPBasicAuth
+import jinja2
 
 # logging
 logging.basicConfig(filename="launch_render_log.txt", level=logging.INFO, format='%(asctime)s :: %(levelname)s :: %(message)s')
@@ -28,9 +29,11 @@ def find_blender_scene():
 
 def send_results(post_data, django_ip, login, password):
 	try_count = 0
+
+	headers = {'Content-type': 'application/json', 'Accept': 'text/plain', 'Content-Encoding': 'utf-8'}
 	while try_count < 3:
 		try:
-			response = requests.post(django_ip, data=post_data, auth=HTTPBasicAuth(login, password))
+			response = requests.post(django_ip, data=json.dumps(post_data), headers=headers, auth=HTTPBasicAuth(login, password))
 			if response.status_code  == 200:
 				logger.info("POST request successfuly sent.")
 				break
@@ -74,11 +77,13 @@ def main():
 	parser.add_argument('--login', required=True)
 	parser.add_argument('--password', required=True)
 	parser.add_argument('--action', required=True)
-	parser.add_argument('--options', required=True)
+	parser.add_argument('--configuration_options', required=True)
+	parser.add_argument('--options_structure', required=True)
 	args = parser.parse_args()
 
 	args.action = args.action.lower()
-	options = json.loads(args.options)
+	configuration_options = json.loads(args.configuration_options)
+	options_structure = json.loads(args.options_structure)
 
 	# create output folder for logs
 	if not os.path.exists('Output'):
@@ -91,12 +96,16 @@ def main():
 	logger.info("Found scene: {}".format(blender_scene))
 
 	# read or write blender scene scanning template
-	with open ("{}_blender_configuration.py".format(args.action)) as f:
-		blender_script_template = f.read()
+	env = jinja2.Environment(
+		loader=jinja2.PackageLoader('launch_blender', '.'),
+		autoescape=True
+	)
+
+	blender_script_template = env.get_template("{}_blender_configuration.py".format(args.action))
 
 	# format template for current scene
 	if args.action == 'read':
-		blender_script = blender_script_template.format(res_path=os.getcwd(), scene_path=blender_scene)
+		blender_script = blender_script_template.render(res_path=os.getcwd(), scene_path=blender_scene, options_structure=options_structure)
 	elif args.action == 'write':
 		blender_script = blender_script_template.format(res_path=os.getcwd(), scene_path=blender_scene, 
 			border_max_x=options['border_max_x'], border_max_y=options['border_max_y'], border_min_x=options['border_min_x'], border_min_y=options['border_min_y'],

--- a/render_service_scripts/scene_scanning/read_blender_configuration.py
+++ b/render_service_scripts/scene_scanning/read_blender_configuration.py
@@ -65,25 +65,25 @@ def render(scene_path):
 	{% for option_structure in options_structure %}
 	report['{{ option_structure }}'] = {}
 
-		{% if options_structure[option_structure].type == 'value' %}
+		{% if options_structure[option_structure].type == 'value' or options_structure[option_structure].type == 'readablevalue' %}
 
 	report['{{ option_structure }}']['value'] = get_value({{ options_structure[option_structure].location }}, '{{ options_structure[option_structure].name }}')
 
-		{% elif options_structure[option_structure].type == 'function' %}
+		{% elif options_structure[option_structure].type == 'function' or options_structure[option_structure].type == 'readablefunction' %}
 
-	report['{{ option_structure }}']['elements'] = {{ options_structure[option_structure].location }}.{{ options_structure[option_structure].name }}(**{{ options_structure[option_structure].args }})
+	report['{{ option_structure }}']['elements'] = {{ options_structure[option_structure].location }}(**{{ options_structure[option_structure].read_args }})
 
 	if ('{{ option_structure }}' == 'missing_files'):
 		report['{{ option_structure }}']['elements'] = list(report['{{ option_structure }}']['elements'])
 
-		{% elif options_structure[option_structure].type == 'object' %}
+		{% elif options_structure[option_structure].type == 'object' or options_structure[option_structure].type == 'readableobject' %}
 
 	report['{{ option_structure }}']['elements'] = []
 
-	report['{{ option_structure }}']['value'] = get_value({{ options_structure[option_structure].selected_location }}, '{{ options_structure[option_structure].selected_name }}')
+	report['{{ option_structure }}']['value'] = get_value({{ options_structure[option_structure].read_selected_location }}, '{{ options_structure[option_structure].read_selected_name }}')
 
 
-	for obj in {{ options_structure[option_structure].location }}.{{ options_structure[option_structure].name }}:
+	for obj in {{ options_structure[option_structure].location }}:
 		if (obj.type == '{{ options_structure[option_structure].obj_type }}'):
 			report['{{ option_structure }}']['elements'].append(obj.name)
 

--- a/render_service_scripts/scene_scanning/read_blender_configuration.py
+++ b/render_service_scripts/scene_scanning/read_blender_configuration.py
@@ -18,7 +18,7 @@ def set_value(path, name, value):
 	if hasattr(path, name):
 		setattr(path, name, value)
 	else:
-		print("No attribute found {{}}".format(name))
+		print("No attribute found {}".format(name))
 
 
 def get_value(path, name):
@@ -46,7 +46,7 @@ def set_render_device():
 def render(scene_path):
 
 	# open scene
-	bpy.ops.wm.open_mainfile(filepath=os.path.join(r"{res_path}", scene_path))
+	bpy.ops.wm.open_mainfile(filepath=os.path.join('{{ res_path }}', scene_path))
 
 	# get scene
 	scene = bpy.context.scene
@@ -60,29 +60,40 @@ def render(scene_path):
 	set_value(scene.rpr.limits, 'seconds', 1800)
 
 	# scene configuration json
-	report = {{}}
-	report['border_max_x'] = get_value(scene.render, 'border_max_x')
-	report['border_max_y'] = get_value(scene.render, 'border_max_y')
-	report['border_min_x'] = get_value(scene.render, 'border_min_x')
-	report['border_min_y'] = get_value(scene.render, 'border_min_y')
-	report['fps'] = get_value(scene.render, 'fps')
-	report['fps_base'] = get_value(scene.render, 'fps_base')
-	report['tile_x'] = get_value(scene.render, 'tile_x')
-	report['tile_y'] = get_value(scene.render, 'tile_y')
 
-	# convert set of missing files to list
-	report['missing_files'] = list(bpy.ops.file.find_missing_files())
+	report = {}
+	{% for option_structure in options_structure %}
+	report['{{ option_structure }}'] = {}
 
-	report['active_camera'] = scene.camera.name
-	report['cameras'] = []
-	for obj in bpy.data.objects:
-		if (obj.type == 'CAMERA'):
-			report['cameras'].append(obj.name)
+		{% if options_structure[option_structure].type == 'value' %}
 
-	with open(os.path.join(r"{res_path}", "scene_info.json"), 'w') as f:
+	report['{{ option_structure }}']['value'] = get_value({{ options_structure[option_structure].location }}, '{{ options_structure[option_structure].name }}')
+
+		{% elif options_structure[option_structure].type == 'function' %}
+
+	report['{{ option_structure }}']['elements'] = {{ options_structure[option_structure].location }}.{{ options_structure[option_structure].name }}(**{{ options_structure[option_structure].args }})
+
+	if ('{{ option_structure }}' == 'missing_files'):
+		report['{{ option_structure }}']['elements'] = list(report['{{ option_structure }}']['elements'])
+
+		{% elif options_structure[option_structure].type == 'object' %}
+
+	report['{{ option_structure }}']['elements'] = []
+
+	report['{{ option_structure }}']['value'] = get_value({{ options_structure[option_structure].selected_location }}, '{{ options_structure[option_structure].selected_name }}')
+
+
+	for obj in {{ options_structure[option_structure].location }}.{{ options_structure[option_structure].name }}:
+		if (obj.type == '{{ options_structure[option_structure].obj_type }}'):
+			report['{{ option_structure }}']['elements'].append(obj.name)
+
+		{% endif  %}
+	{% endfor %}
+
+	with open(os.path.join('{{ res_path }}', "scene_info.json"), 'w') as f:
 		json.dump(report, f, indent=' ')
 
 
 if __name__ == "__main__":
 	initializeRPR()
-	render(r'{scene_path}')
+	render('{{ scene_path }}')

--- a/render_service_scripts/scene_scanning/write_blender_configuration.py
+++ b/render_service_scripts/scene_scanning/write_blender_configuration.py
@@ -65,7 +65,13 @@ def render(scene_path):
 	{% for option_structure in options_structure %}
 		{% if options_structure[option_structure].type == 'value' or options_structure[option_structure].type == 'writablevalue' %}
 
+		{% if options_structure[option_structure].value_type == 'string' %}
+	set_value({{ options_structure[option_structure].location }}, '{{ options_structure[option_structure].name }}', '{{ configuration_options[option_structure] }}')
+		{% elif options_structure[option_structure].value_type == 'numeric' %}
 	set_value({{ options_structure[option_structure].location }}, '{{ options_structure[option_structure].name }}', {{ configuration_options[option_structure] }})
+		{% elif options_structure[option_structure].value_type == 'boolean' %}
+	set_value({{ options_structure[option_structure].location }}, '{{ options_structure[option_structure].name }}', '{{ configuration_options[option_structure] }}' == 'True')
+		{% endif %}
 
 		{% elif options_structure[option_structure].type == 'function' or options_structure[option_structure].type == 'writablefunction' %}
 
@@ -93,13 +99,7 @@ def render(scene_path):
 
 		{% if options_structure[option_structure].type == 'value' or options_structure[option_structure].type == 'readablevalue' %}
 
-		{% if options_structure[option_structure].value_type == 'string' %}
 	report['{{ option_structure }}']['value'] = get_value({{ options_structure[option_structure].location }}, '{{ options_structure[option_structure].name }}')
-		{% elif options_structure[option_structure].value_type == 'numeric' %}
-	report['{{ option_structure }}']['value'] = get_value({{ options_structure[option_structure].location }}, {{ options_structure[option_structure].name }})
-		{% elif options_structure[option_structure].value_type == 'boolean' %}
-	report['{{ option_structure }}']['value'] = get_value({{ options_structure[option_structure].location }}, '{{ options_structure[option_structure].name }}' == 'True')
-		{% endif %}
 
 		{% elif options_structure[option_structure].type == 'function' or options_structure[option_structure].type == 'readablefunction' %}
 

--- a/render_service_scripts/scene_scanning/write_blender_configuration.py
+++ b/render_service_scripts/scene_scanning/write_blender_configuration.py
@@ -18,7 +18,7 @@ def set_value(path, name, value):
 	if hasattr(path, name):
 		setattr(path, name, value)
 	else:
-		print("No attribute found {{}}".format(name))
+		print("No attribute found {}".format(name))
 
 
 def get_value(path, name):
@@ -45,7 +45,7 @@ def set_render_device():
 
 def init(scene_path):
 	# open scene
-	bpy.ops.wm.open_mainfile(filepath=os.path.join(r"{res_path}", scene_path))
+	bpy.ops.wm.open_mainfile(filepath=os.path.join('{{ res_path }}', scene_path))
 	# get scene
 	scene = bpy.context.scene
 	# enable rpr
@@ -62,56 +62,64 @@ def render(scene_path):
 
 	set_value(scene.rpr.limits, 'seconds', 1800)
 
-	if {border_max_x}:
-		set_value(scene.render, 'border_max_x', {border_max_x})
-	if {border_max_y}:
-		set_value(scene.render, 'border_max_y', {border_max_y})
-	if {border_min_x}:
-		set_value(scene.render, 'border_min_x', {border_min_x})
-	if {border_min_y}:
-		set_value(scene.render, 'border_min_y', {border_min_y})
-	if {fps}:
-		set_value(scene.render, 'fps', {fps})
-	if {fps_base}:
-		set_value(scene.render, 'fps_base', {fps_base})
-	if {tile_x}:
-		set_value(scene.render, 'tile_x', {tile_x})
-	if {tile_y}:
-		set_value(scene.render, 'tile_y', {tile_y})
-	if "{camera}":
-		for obj in bpy.data.objects:
-			if (obj.type == 'CAMERA' and obj.name == "{camera}"):
-				set_value(scene, 'camera', obj)
+	{% for option_structure in options_structure %}
+		{% if options_structure[option_structure].type == 'value' or options_structure[option_structure].type == 'writablevalue' %}
+
+	set_value({{ options_structure[option_structure].location }}, '{{ options_structure[option_structure].name }}', {{ configuration_options[option_structure] }})
+
+		{% elif options_structure[option_structure].type == 'function' or options_structure[option_structure].type == 'writablefunction' %}
+
+	{{ options_structure[option_structure].location }}({{ options_structure[option_structure].value_arg_name }}='{{ configuration_options[option_structure] }}', **{{ options_structure[option_structure].read_args }})
+
+		{% elif options_structure[option_structure].type == 'object' or options_structure[option_structure].type == 'writableobject' %}
+
+	for obj in {{ options_structure[option_structure].location }}:
+		if (obj.type == '{{ options_structure[option_structure].obj_type }}' and obj.name == '{{ configuration_options[option_structure] }}'):
+			set_value({{ options_structure[option_structure].write_selected_location }}, '{{ options_structure[option_structure].write_selected_name }}', obj)
+
+		{% endif  %}
+	{% endfor %}
 
 	# write and reopen scene
-	bpy.ops.wm.save_as_mainfile(filepath=os.path.join(r"{res_path}", scene_path))
+	bpy.ops.wm.save_as_mainfile(filepath=os.path.join('{{ res_path }}', scene_path))
 	
 	scene = init(scene_path)
 
 	# scene configuration json
-	report = {{}}
-	report['border_max_x'] = get_value(scene.render, 'border_max_x')
-	report['border_max_y'] = get_value(scene.render, 'border_max_y')
-	report['border_min_x'] = get_value(scene.render, 'border_min_x')
-	report['border_min_y'] = get_value(scene.render, 'border_min_y')
-	report['fps'] = get_value(scene.render, 'fps')
-	report['fps_base'] = get_value(scene.render, 'fps_base')
-	report['tile_x'] = get_value(scene.render, 'tile_x')
-	report['tile_y'] = get_value(scene.render, 'tile_y')
 
-	# convert set of missing files to list
-	report['missing_files'] = list(bpy.ops.file.find_missing_files())
+	report = {}
+	{% for option_structure in options_structure %}
+	report['{{ option_structure }}'] = {}
 
-	report['active_camera'] = scene.camera.name
-	report['cameras'] = []
-	for obj in bpy.data.objects:
-		if (obj.type == 'CAMERA'):
-			report['cameras'].append(obj.name)
+		{% if options_structure[option_structure].type == 'value' or options_structure[option_structure].type == 'readablevalue' %}
 
-	with open(os.path.join(r"{res_path}", "scene_info.json"), 'w') as f:
+	report['{{ option_structure }}']['value'] = get_value({{ options_structure[option_structure].location }}, '{{ options_structure[option_structure].name }}')
+
+		{% elif options_structure[option_structure].type == 'function' or options_structure[option_structure].type == 'readablefunction' %}
+
+	report['{{ option_structure }}']['elements'] = {{ options_structure[option_structure].location }}(**{{ options_structure[option_structure].read_args }})
+
+	if ('{{ option_structure }}' == 'missing_files'):
+		report['{{ option_structure }}']['elements'] = list(report['{{ option_structure }}']['elements'])
+
+		{% elif options_structure[option_structure].type == 'object' or options_structure[option_structure].type == 'readableobject' %}
+
+	report['{{ option_structure }}']['elements'] = []
+
+	report['{{ option_structure }}']['value'] = get_value({{ options_structure[option_structure].read_selected_location }}, '{{ options_structure[option_structure].read_selected_name }}')
+
+
+	for obj in {{ options_structure[option_structure].location }}:
+		if (obj.type == '{{ options_structure[option_structure].obj_type }}'):
+			report['{{ option_structure }}']['elements'].append(obj.name)
+
+		{% endif  %}
+	{% endfor %}
+
+	with open(os.path.join('{{ res_path }}', "scene_info.json"), 'w') as f:
 		json.dump(report, f, indent=' ')
 
 
 if __name__ == "__main__":
 	initializeRPR()
-	render(r'{scene_path}')
+	render('{{ scene_path }}')

--- a/render_service_scripts/scene_scanning/write_blender_configuration.py
+++ b/render_service_scripts/scene_scanning/write_blender_configuration.py
@@ -93,7 +93,13 @@ def render(scene_path):
 
 		{% if options_structure[option_structure].type == 'value' or options_structure[option_structure].type == 'readablevalue' %}
 
+		{% if options_structure[option_structure].value_type == 'string' %}
 	report['{{ option_structure }}']['value'] = get_value({{ options_structure[option_structure].location }}, '{{ options_structure[option_structure].name }}')
+		{% elif options_structure[option_structure].value_type == 'numeric' %}
+	report['{{ option_structure }}']['value'] = get_value({{ options_structure[option_structure].location }}, {{ options_structure[option_structure].name }})
+		{% elif options_structure[option_structure].value_type == 'boolean' %}
+	report['{{ option_structure }}']['value'] = get_value({{ options_structure[option_structure].location }}, '{{ options_structure[option_structure].name }}' == 'True')
+		{% endif %}
 
 		{% elif options_structure[option_structure].type == 'function' or options_structure[option_structure].type == 'readablefunction' %}
 


### PR DESCRIPTION
* JIRA TICKET:
  * https://adc.luxoft.com/jira/browse/STVCIS-1102
* PURPOSE
  * Implement scene scanning API for Blender scenes for configure desired options from config file (without changes in DB schema and render service scripts)
* EFFECT OF CHANGE
  * Replace blender script building tool (Python format method -> jinja2 library).
  * Generate configurable options based on information which are sent from render service.
* RELATED PRs:
  * render_service: https://gitlab.cts.luxoft.com/services/render_service/-/merge_requests/53
  * rpr_pipelines: https://github.com/luxteam/rpr_pipelines/pull/209